### PR TITLE
Update XKR.network nodes

### DIFF
--- a/nodes.json
+++ b/nodes.json
@@ -62,8 +62,8 @@
         },
         {
             "name": "XKR.network",
-            "url": "xkr.network",
-            "port": 11898,
+            "url": "node.xkr.network",
+            "port": 80,
             "ssl": false,
             "cache": false,
             "version": "1.1.1",
@@ -71,9 +71,9 @@
             "proxy_url": "xkrnetwork"
         },
         {
-            "name": "XKR.network",
-            "url": "xkr.network",
-            "port": 21898,
+            "name": "XKR.network SSL",
+            "url": "node.xkr.network",
+            "port": 443,
             "ssl": true,
             "cache": false,
             "version": "1.1.1",


### PR DESCRIPTION
This pull request makes a few updates to my node (XKR.network) in the public node list:

1. **Subdomain Addition**: The node has been updated to use the `node.xkr.network` subdomain, this change enables the use of ports 80 and 443, as these are already allocated for the website on the primary domain.
2. **Port Change**: The node ports have been changed from 11898 and 21898 to the standard ports 80 and 443. This change should circumvent any potential network restrictions of the less common ports 11898 and 21898, to hopefully allow those with restricted internet access to still access the node.
3. **Backward Compatibility**: The previous node addresses (`xkr.network:11898` and `xkr.network:21898`) will still be available just like before.
4. **SSL Node Naming Update**: The name of the SSL node has been updated to include an 'SSL' suffix for a clearer distinction.