### PR TITLE
Add node.kryptokrona.no node

### DIFF
--- a/nodes.json
+++ b/nodes.json
@@ -79,6 +79,16 @@
             "version": "1.1.1",
             "fee": "0.0",
             "proxy_url": "xkrnetwork"
+        },
+	{
+            "name": "Kryptokrona.no",
+            "url": "node.kryptokrona.no",
+            "port": 11898,
+            "ssl": false,
+            "cache": false,
+            "version": "1.1.1",
+            "fee": "0.0",
+            "proxy_url": "kryptokronano"
         }
     ],
     "apis": [


### PR DESCRIPTION
This pull request adds the public node Kryptokrona.no (`node.kryptokrona.no:11898`) by Pokerfjes (Discord: tango1675) to the public node list. The node name or proxy_url can be changed to something different if desired.